### PR TITLE
Adc driver development

### DIFF
--- a/old_mains/sample_adc_with_timer_and_dma.c
+++ b/old_mains/sample_adc_with_timer_and_dma.c
@@ -139,7 +139,7 @@ void adc_tim_scan_example(volatile uint16_t *out_arr, const uint8_t arr_len) {
               .resolution = ADC_RESOLUTION_12_BIT,
               .interrupt_en = ADC_INTERRUPT_ENABLE,
               .trigger_cfg = {.mode = ADC_TRIGGER_MODE_CONTINUOUS,
-                              .timer_sel = ADC_TRIGGER_TIM5_CH1,
+                              .timer_sel = ADC_TRIGGER_T5C1_JT5C4,
                               .edge_sel = ADC_TRIGGER_EDGE_RISING}}};
   adc_peri_clock_control(ADC1, ADC_PERI_CLOCK_ENABLE);
   adc_init(&adc_init_struct);


### PR DESCRIPTION
This pull request includes a couple of changes to update a submodule commit reference and modify an ADC timer selection in a sample code file.

### Key changes:

* **Submodule update:**
  * [`drivers`](diffhunk://#diff-a71518107f3a70bc9b544c75c80bdffa8e8e0def85f68c3277f763d3dd82da32L1-R1): Updated submodule commit reference from `1e97226d5dac01f3269273ec1faa4705365e8fe2` to `ee15f8ec437db44e65433bc69d796edd033718d2`.

* **ADC timer selection modification:**
  * [`old_mains/sample_adc_with_timer_and_dma.c`](diffhunk://#diff-50083b350330a429dba1afa099d8796671963699eaa72e139672c966f47f3bb8L142-R142): Changed the `timer_sel` configuration from `ADC_TRIGGER_TIM5_CH1` to `ADC_TRIGGER_T5C1_JT5C4` in the `adc_tim_scan_example` function.